### PR TITLE
Merge development into main - New Features! Wupp wupp

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,0 +1,7 @@
+export * from "./src/core/plugin-base";
+export * from "./src/core/plugin-loader";
+export * from "./src/core/plugin-registry";
+
+export * from "./src/@types/plugin-system.types";
+
+export { default } from "./src/core/plugin-manager";

--- a/readme.md
+++ b/readme.md
@@ -4,10 +4,10 @@ Don't you hate it when you have so many modules, plugins, packages or however yo
 
 Well god bless you because you found this sweet little piece of code :D
 
-Usage
+### Usage
 
 ```typescript
-import PluginManager from "<where-ever-you-have-it-laying-around>";
+import PluginManager from "<wherever-you-have-it-laying-around>";
 
 // Register your plugins and their dependencies
 PluginManager.register(PluginA.name, PluginA, [PluginB.name]);
@@ -18,18 +18,23 @@ PluginManager.register(PluginC.name, PluginC);
 PluginManager.override(PluginC.name, PluginD);
 PluginManager.override(PluginB.name, PluginE, [PluginC.name]);
 
-// Kickoff the loader and instantiate/initilaize the plugins
+// Kick off the loader and instantiate/initialize the plugins
 PluginManager.init();
 ```
 
-And you are really fancy
+And if you are really fancy
 
 ```typescript
-// When initializing you can pass down your own loader ... uhhhh
+// When initializing you can pass down your own loader .. uhhhh
 PluginManager.init(MyVeryOwnFancyPluginLoader);
+
+// Or using the setter ..
+PluginManager.setLoader(MyOtherVeryOwnFancyPluginLoader);
+// .. and initialize later
+PluginManager.init();
 ```
 
-## Features
+### Features
 
-- Multiplugin handling with respect to their dependencies
-- Detect circular dependencies (Nice to be able to handle them, but not yet)
+- Dependency first loading strategy
+- Detects circular dependencies (Nice to be able to handle them, but not yet)

--- a/src/@types/helper.types.ts
+++ b/src/@types/helper.types.ts
@@ -29,3 +29,10 @@ export const isClass = <ClassType>(
   value: any
 ): value is ClassBlueprint<ClassType> =>
   typeof value == "function" && value.toString().includes("class");
+
+export type MultivariateFunction<ReturnType = any> = (
+  ...args: any[]
+) => ReturnType;
+export type MultivariateFunctionAsync<ReturnType = any> = (
+  ...args: any[]
+) => Promise<ReturnType>;

--- a/src/@types/plugin-system.types.ts
+++ b/src/@types/plugin-system.types.ts
@@ -4,17 +4,17 @@
  */
 
 export interface PluginBaseInterface {
-  beforeInit?: () => boolean;
+  beforeInit?: (wusa: number) => boolean;
   init?: (() => boolean) | (() => Promise<boolean>);
   shutdown?: () => void;
   afterInit?: () => boolean;
 }
 
 export type PluginFactorySignature =
-  | (() => PluginBaseInterface)
-  | (() => Promise<PluginBaseInterface>);
+  | ((...args: any[]) => PluginBaseInterface | boolean)
+  | ((...args: any[]) => Promise<PluginBaseInterface | boolean>);
 export interface PluginConstructionClass {
-  new (): PluginBaseInterface;
+  new (...args: any[]): PluginBaseInterface;
 }
 export type PluginConstructor =
   | PluginFactorySignature
@@ -34,7 +34,7 @@ export interface PluginInstance {
   instance?: PluginBaseInterface;
 }
 
-export interface PluginRegisterOptions {
+export interface PluginRegistrationOptions {
   identifier: string;
   constructor: PluginConstructor;
   dependencies: string[];
@@ -106,15 +106,17 @@ export interface PluginManagerInterface extends PluginRegistryInterface {
   init: () => Promise<boolean>;
 
   /**
-   * Instantiates a plugin
+   * Initiates the construction of a plugin class
+   * or execution of a plugin factory function
    *
    * @param identifier identifier Unique plugin identifier
    * @returns The created plugin instance
-   * @returns False if the plugin was not found
+   * @returns Boolean on factory execution
+   * @returns Null if the plugin was not found
    */
-  instantiate: <P extends PluginBaseInterface>(
+  initiate: <P extends PluginBaseInterface>(
     identifier: string
-  ) => Promise<P | false>;
+  ) => Promise<P | boolean | null>;
 
   /**
    * Triggers a plugins shutdown and kills it afterwards

--- a/src/@types/plugin-system.types.ts
+++ b/src/@types/plugin-system.types.ts
@@ -4,7 +4,7 @@
  */
 
 export interface PluginBaseInterface {
-  beforeInit?: (wusa: number) => boolean;
+  beforeInit?: () => boolean;
   init?: (() => boolean) | (() => Promise<boolean>);
   shutdown?: () => void;
   afterInit?: () => boolean;

--- a/src/core/plugin-helper.ts
+++ b/src/core/plugin-helper.ts
@@ -1,0 +1,34 @@
+/**
+ * @Author Alexander Bassov Sat Oct 13 2024
+ * @Email blackxes.dev@gmail.com
+ */
+
+import {
+  isAsyncFunction,
+  MultivariateFunction,
+  MultivariateFunctionAsync,
+} from "../@types/helper.types";
+
+export const executeFunction = async <
+  ReturnType = any,
+  ThisType extends object = object
+>(
+  callback:
+    | MultivariateFunction<ReturnType>
+    | MultivariateFunctionAsync<ReturnType>
+    | undefined,
+  _this?: ThisType,
+  ...args: any[]
+) => {
+  if (callback === undefined) {
+    return;
+  }
+
+  if (typeof callback != "function") {
+    throw new Error("Expected ");
+  }
+
+  return isAsyncFunction(callback)
+    ? await callback.apply(_this, args)
+    : callback.apply(_this, args);
+};

--- a/src/core/plugin-loader.ts
+++ b/src/core/plugin-loader.ts
@@ -50,7 +50,7 @@ export class RecursivePluginLoader implements PluginLoaderInterface {
         await this._load(registryItem.dependencies, identifier);
       }
 
-      if ((await PluginManager.instantiate(identifier)) === false) {
+      if ((await PluginManager.initiate(identifier)) === false) {
         throw new Error(`Couldn't instantiate plugin "${identifier}"`);
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,0 @@
-export * from "./core/plugin-base";
-export * from "./core/plugin-loader";
-export * from "./core/plugin-registry";
-
-export * from "./@types/plugin-system.types";
-
-export { default } from "./core/plugin-manager";

--- a/src/tests/helper.ts
+++ b/src/tests/helper.ts
@@ -1,0 +1,12 @@
+/**
+ * @Author Alexander Bassov Sun Oct 06 2024
+ * @Email blackxes.dev@gmail.com
+ */
+
+function Log(message: string) {
+  return function (target: any) {
+    console.log(`[${target?.name}] ${message}`);
+  };
+}
+
+export { Log };

--- a/src/tests/test-recursive-loading/plugins/plugins-class-async.ts
+++ b/src/tests/test-recursive-loading/plugins/plugins-class-async.ts
@@ -1,0 +1,46 @@
+/**
+ * @Author Alexander Bassov Sun Oct 06 2024
+ * @Email blackxes.dev@gmail.com
+ */
+
+import { PluginBase } from "../../../core/plugin-base";
+
+export class TestPlugin_ClassA_InitAsync extends PluginBase {
+  public async init(ms: number = 1000, resolveValue: boolean = true) {
+    return await new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(resolveValue), ms)
+    );
+  }
+}
+
+export class TestPlugin_ClassB_InitAsync extends PluginBase {
+  public async init(ms: number = 1000, resolveValue: boolean = true) {
+    return await new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(resolveValue), ms)
+    );
+  }
+}
+
+export class TestPlugin_ClassC_InitAsync extends PluginBase {
+  public async init(ms: number = 1000, resolveValue: boolean = true) {
+    return await new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(resolveValue), ms)
+    );
+  }
+}
+
+export class TestPlugin_ClassD_InitAsync extends PluginBase {
+  public async init(ms: number = 1000, resolveValue: boolean = true) {
+    return await new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(resolveValue), ms)
+    );
+  }
+}
+
+export class TestPlugin_ClassE_InitAsync extends PluginBase {
+  public async init(ms: number = 1000, resolveValue: boolean = true) {
+    return await new Promise<boolean>((resolve) =>
+      setTimeout(() => resolve(resolveValue), ms)
+    );
+  }
+}

--- a/src/tests/test-recursive-loading/plugins/plugins-class-sync.ts
+++ b/src/tests/test-recursive-loading/plugins/plugins-class-sync.ts
@@ -1,0 +1,71 @@
+/**
+ * @Author Alexander Bassov Sun Oct 06 2024
+ * @Email blackxes.dev@gmail.com
+ */
+
+import { PluginFactorySignature } from "../../../@types/plugin-system.types";
+import { PluginBase } from "../../../core/plugin-base";
+
+export class TestPlugin_ClassA_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%cTestPlugin_ClassA_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export class TestPlugin_ClassB_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%TestPlugin_ClassB_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export class TestPlugin_ClassC_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%TestPlugin_ClassC_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export class TestPlugin_ClassD_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%TestPlugin_ClassD_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export class TestPlugin_ClassE_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%TestPlugin_ClassE_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export class TestPlugin_ClassF_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%TestPlugin_ClassF_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export class TestPlugin_ClassG_InitSync extends PluginBase {
+  public init(returnValue: boolean = true) {
+    console.log("%TestPlugin_ClassG_InitSync initialized", "color: grey");
+    return returnValue;
+  }
+}
+
+export const TestPlugin_Factory_Sync: PluginFactorySignature = (
+  returnValue: boolean
+) => {
+  return returnValue;
+};
+
+export const TestPlugin_Factory_Async: PluginFactorySignature = async (
+  ms: number,
+  returnValue: boolean
+) => {
+  return new Promise<boolean>((resolve) =>
+    setTimeout(() => resolve(returnValue), ms)
+  );
+};

--- a/src/tests/test-recursive-loading/test-recursive-loading.test.ts
+++ b/src/tests/test-recursive-loading/test-recursive-loading.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { expect, test } from "vitest";
-import PluginManager from "../../index";
+import PluginManager from "../../core/plugin-manager";
 import {
   PluginA,
   PluginB,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true,
     "paths": {
-      "plugin-system-ts": ["./src/index"]
+      "plugin-system-ts": ["./index"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
In general plugins are now not "instantiated" but rather "initiated".
Meaning that the plugin manager on initiated a plugin resolves the construction method, be it a factory or a class, and continues to execute their hooks and initializations if they return an object.

I don't have a better naming, but "instantiating" a plugin does not imply that the plugin may just be a simple anonymous function which does nothing but being executed and thats it.

New features overview
- Added support for async plugin factories and async plugin initializations
- Added support for variadic functions for all plugin creation methods and initializations
- Added better return types for handling plugin initiations

- Fixed spelling mistakes
- Changed some interface names